### PR TITLE
fix: forgot to add andorra telecom button styles

### DIFF
--- a/src/content-scripts/TaskButton.svelte
+++ b/src/content-scripts/TaskButton.svelte
@@ -332,6 +332,49 @@
     }
   }
 
+  .button.andorratelecom {
+    margin: 0;
+    margin-right: 10px;
+    padding: 0 20px;
+    color: #333;
+    font-weight: bold;
+    font-size: 14px;
+    font-family: 'wf_segoe-ui_semibold', 'Segoe UI Semibold',
+      'Segoe WP Semibold', 'Segoe UI', 'Segoe WP', Tahoma, Arial, sans-serif;
+    line-height: 2;
+    background-color: #f7e0e2;
+    border: 1px solid #f7e0e2;
+    border-radius: 0;
+    cursor: pointer;
+
+    &:focus {
+      border-color: #d5006d;
+    }
+
+    &:hover {
+      background-color: #f0c1c5;
+      border-color: #f0c1c5;
+    }
+
+    &:active {
+      color: #ffffff;
+      background-color: #d5006d;
+      border-color: #d5006d;
+    }
+
+    &.decrypt {
+      margin: 8px 0;
+    }
+
+    &.encrypt {
+      float: left;
+    }
+
+    > :global(svg) {
+      vertical-align: middle;
+    }
+  }
+
   // Make the tooltip a flex container, to allow the Cancel button
   // to be in the right-hand side of the tooltip
   .tooltip {


### PR DESCRIPTION
Added style for buttons
Normal
![Screenshot from 2021-09-16 10-16-38](https://user-images.githubusercontent.com/29331799/133587031-a996b629-3cac-42f0-929d-96931214f247.png)

Hover
![Screenshot from 2021-09-16 10-17-01](https://user-images.githubusercontent.com/29331799/133587077-eeaeccf5-9be6-4ef7-984f-f59d8a14fc0f.png)

Clicked
![Screenshot from 2021-09-16 10-17-22](https://user-images.githubusercontent.com/29331799/133587090-cb172ec0-8ea0-427d-8d39-9d5ff295a5cf.png)
