### PR TITLE
feat: added support for yandex

### DIFF
--- a/src/content-scripts/TaskButton.svelte
+++ b/src/content-scripts/TaskButton.svelte
@@ -478,6 +478,41 @@
     }
   }
 
+  .button.yandex {
+    position: relative;
+    margin-left: 5px;
+    padding: 0px 12px;
+    color: var(--liza-theme-accent-text-color);
+    font-weight: 900;
+    font-size: 14px;
+    font-family: 'YS Text', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    line-height: 2;
+    background-color: var(--liza-theme-accent-color);
+    border: 0px;
+    border-radius: 100px;
+
+    &:hover,
+    &:focus {
+      background-color: var(--liza-theme-accent-color-hover);
+    }
+
+    &:active {
+      background-color: var(--liza-theme-accent-color-active);
+    }
+
+    &.decrypt {
+      margin: 8px 0;
+    }
+
+    &.encrypt {
+      margin-inline-end: 0px;
+    }
+    > :global(svg) {
+      display: inline !important;
+      vertical-align: middle;
+    }
+  }
+
   // Make the tooltip a flex container, to allow the Cancel button
   // to be in the right-hand side of the tooltip
   .tooltip {

--- a/src/content-scripts/design.ts
+++ b/src/content-scripts/design.ts
@@ -10,5 +10,6 @@ export enum Design {
   Telegram = 'telegram',
   WhatsApp = 'whatsapp',
   Yahoo = 'yahoo',
+  Yandex = 'yandex',
   iCloud = 'icloud',
 }

--- a/src/content-scripts/yandex.ts
+++ b/src/content-scripts/yandex.ts
@@ -1,0 +1,230 @@
+/* eslint-disable complexity */
+/* eslint-disable sonarjs/cognitive-complexity */
+
+/**
+ * Yandex functions for content scripts.
+ *
+ * @module
+ * @see {@link Yandex}
+ */
+
+import type { Report } from '$/report'
+import { debug } from 'debug'
+import tippy from 'tippy.js'
+import { _ } from '$/i18n'
+import { ErrorMessage, ExtensionError } from '~src/error'
+import EncryptButton from './EncryptButton.svelte'
+import { Design } from './design'
+import { Webmail, FLAG, Selectors } from './webmail'
+
+/** HTMLElements from all the parts of a certain window */
+export interface MailElements {
+  toolbar?: HTMLElement | null
+  editor?: HTMLElement | null
+  editorContent?: HTMLElement | null
+  send?: HTMLElement | null
+}
+
+/**
+ * Yandex has two different window editors that can pop up at the same time, one
+ * is from the response of a mail, and the other one is from the one that
+ * appears when you want to create a new mail, so we always have to keep track
+ * of the elements that corresponds to each window editor, to handle the double
+ * editor, every time we call the {@link handleToolbar} we send the entire
+ * interface of each window editors so every one knows where its elements are
+ * and don't interfere with the other window editor
+ */
+
+export class Yandex extends Webmail {
+  /**
+   * Handles mutations observed by the `MutationObserver` below, i.e.
+   * notifications of elements added or removed from the page.
+   */
+  protected handleMutations = (): void => {
+    const mails = document.body.querySelectorAll<HTMLElement>(
+      this.selectors.mail
+    )
+    for (const mail of mails) this.handleMailElement(mail)
+
+    // First window of yandex editor
+    const firstWindow = document.querySelector(
+      '.ns-view-quick-reply-form-wrap.mail-QuickReply-FormWrap'
+    )
+    // Second window of yandex editor
+    const secondWindow = document.querySelector('.ComposePopup-Content')
+
+    if (!firstWindow && !secondWindow) return
+
+    /** Create a new MailElement */
+    const mailElement: MailElements = {}
+
+    /** If both windows are shown */
+    if (firstWindow && secondWindow) {
+      /** Array of Elements to iterate over all elements for both windows editors in Yandex */
+      const windows: Element[] = [firstWindow, secondWindow]
+
+      for (const window_ of windows) {
+        mailElement.toolbar = window_.querySelector<HTMLElement>(
+          this.selectors.toolbar
+        )
+        console.log('mailElement.toolbar:', mailElement.toolbar)
+        mailElement.editor = window_.querySelector<HTMLElement>(
+          this.selectors.editor
+        )
+        console.log('mailElement.editor:', mailElement.editor)
+        mailElement.editorContent = window_.querySelector<HTMLElement>(
+          this.selectors.editorContent
+        )
+        console.log('mailElement.editorContent:', mailElement.editorContent)
+        mailElement.send = window_.querySelector<HTMLElement>(
+          this.selectors.send
+        )
+        console.log('mailElement.send:', mailElement.send)
+        this.handleToolbarYandex(mailElement)
+      }
+    } else {
+      /**
+       * If only one of both the windows are shown generalWindow variable will
+       * be the only active window, and then do the same as above, assign all
+       * the elements from the Selectors and the call the function
+       */
+      let generalWindow: Element | undefined | null
+      if (firstWindow) generalWindow = firstWindow
+      else if (secondWindow) generalWindow = secondWindow
+
+      mailElement.toolbar = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.toolbar
+      )
+      mailElement.editor = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.editor
+      )
+      mailElement.editorContent = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.editorContent
+      )
+      mailElement.send = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.send
+      )
+      this.handleToolbarYandex(mailElement)
+    }
+  }
+
+  /** Adds an encryption button in the toolbar. */
+  protected handleToolbarYandex = (mailElements: MailElements): void => {
+    if (mailElements.toolbar === null || mailElements.toolbar === undefined)
+      return
+
+    const node = mailElements.toolbar.firstElementChild
+
+    if (
+      !mailElements.editor ||
+      !mailElements.editorContent ||
+      !mailElements.send ||
+      !node
+    )
+      return
+
+    if (FLAG in mailElements.toolbar.dataset) return
+    mailElements.toolbar.dataset[FLAG] = '1'
+
+    const target = document.createElement('span')
+    target.id = 'EncryptButton'
+    target.style.display = 'contents'
+    const { design } = this
+    const button = new EncryptButton({
+      target,
+      props: { design },
+    })
+    node.after(target)
+
+    const tooltip = tippy(mailElements.send, {
+      theme: 'light-border',
+    })
+    _.subscribe(($_) => {
+      tooltip.setContent($_('this-mail-is-not-encrypted'))
+    })
+
+    this.addClickListener(
+      button,
+      async (promise, resolved, rejected, signal) => {
+        if (promise && !resolved && !rejected) return promise
+        if (mailElements.editorContent === undefined) return
+        if (mailElements.editorContent?.textContent === '')
+          throw new ExtensionError(ErrorMessage.MailContentUndefined)
+
+        button.$set({ report: undefined })
+        if (mailElements.editorContent === null) return
+        // Encrypt and replace
+        let encryptedString = await this.encryptString(
+          // Use innerHTML instead of textContent to support rich text
+          mailElements.editorContent.innerHTML,
+          (report: Report) => {
+            button.$set({ report })
+          },
+          signal
+        )
+
+        encryptedString += '\r'
+
+        mailElements.editorContent.innerHTML = ''
+        // For some reason yandex messages needs to be in the following format to be able to detect
+        // injected text like our encrypted string
+        // part message 1<br>
+        // part message 2<br> etc...
+        let position: number
+        let aux = encryptedString
+        const pre = document.createElement('pre')
+        /**
+         * The way I do it it always remains one \n at the end to the final
+         * length is going to be 1
+         */
+        while (encryptedString.length !== 1) {
+          position = encryptedString.indexOf('\n')
+          aux = encryptedString.slice(0, position)
+          encryptedString = encryptedString.slice(
+            position + 1,
+            encryptedString.length
+          )
+
+          const br = document.createElement('br')
+          pre.append(aux)
+          pre.append(br)
+        }
+
+        mailElements.editorContent.append(pre)
+        const event = new InputEvent('input', { bubbles: true })
+        mailElements.editorContent.dispatchEvent(event)
+
+        tooltip.destroy()
+      }
+    )
+  }
+}
+
+/** Selectors for interesting HTML Elements of Yandex. */
+/** Both windows from yandex shares the same class selectors */
+const selectors: Selectors = {
+  /** The mail selectors */
+  mail: '.js-message-body-content.mail-Message-Body-Content',
+  /**
+   * First selector is from the window of the new mail and second selector is
+   * from the second window
+   */
+  toolbar:
+    'div.ComposeControlPanel-Part:nth-child(1), .mail-Compose-Field-Actions_left',
+  /** For editor and editorContent both window editors share the same selectors */
+  editor: '.cke_inner.cke_reset',
+  editorContent: '.cke_editable.cke_editable_themed',
+  /**
+   * First selector is from the window of the new mail and second selector is
+   * from the second window
+   */
+  send: '.ComposeControlPanel-SendButton, .mail-Compose-From-SendButton',
+}
+
+// Enable logging in the page console (not the extension console)
+if (process.env.NODE_ENV !== 'production') debug.enable('*')
+
+setTimeout(() => {
+  const webmail = new Yandex(selectors, Design.Yandex)
+  webmail.observe()
+}, 2000)

--- a/webmails.json
+++ b/webmails.json
@@ -1,9 +1,9 @@
 {
-  "icloud": ["https://www-mail.icloud-sandbox.com/*"],
   "andorratelecom": ["https://correu.andorra.ad/owa/*"],
   "gmail": ["https://mail.google.com/mail/*"],
   "govern-full": ["https://missatgeria.govern.ad/*"],
   "govern-light": ["https://missatgeria.govern.ad/*"],
+  "icloud": ["https://www-mail.icloud-sandbox.com/*"],
   "linkedin": ["https://www.linkedin.com/*"],
   "outlook": ["https://outlook.live.com/mail/*"],
   "outlook-old": ["https://webmail.mail.ovh.net/owa/*"],
@@ -11,5 +11,6 @@
   "roundcube": ["https://mail.ovh.net/owa/*"],
   "telegram": ["https://web.telegram.org/k/*"],
   "whatsapp": ["https://web.whatsapp.com/*"],
-  "yahoo": ["https://mail.yahoo.com/*"]
+  "yahoo": ["https://mail.yahoo.com/*"],
+  "yandex": ["https://mail.yandex.com/*"]
 }


### PR DESCRIPTION
General overview of the implementation on Yandex webmail

Buttons colors match apparence from Yandex
![1 1-match-colors](https://user-images.githubusercontent.com/29331799/142639184-7b2c9293-f1e7-44f5-84bc-7d5baa77e0e9.png)
![1-matching-colors](https://user-images.githubusercontent.com/29331799/142639239-23837d79-e0df-4c57-86d1-138a9f02c3c2.png)

Decrypt Button
![2-decrypt](https://user-images.githubusercontent.com/29331799/142639255-3df90448-9be1-4a34-a330-a6181d425f5d.png)

Encrypt Button in first window (response window)
![3-encrypt-response](https://user-images.githubusercontent.com/29331799/142639279-581f835c-0abe-4b0f-a2b6-03423c2ec4dc.png)

Encrypt Button in second window (new message window)
![3 1-encrypt-new-message](https://user-images.githubusercontent.com/29331799/142639322-608835a8-5961-4892-93db-3d88f7495b4a.png)