### PR TITLE
fix: linkedin now detects if mail is empty to encrypt

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -11,6 +11,7 @@
     "evitoken",
     "freemindtronic",
     "gmail",
+    "linkedin",
     "monospace",
     "openpgp",
     "roundcube",
@@ -109,6 +110,10 @@
     {
       "filename": "src/content-scripts/govern-full.ts",
       "ignoreWords": ["contentpanel", "editorframe", "mailedit", "bodyrich"]
+    },
+    {
+      "filename": "src/content-scripts/linkedin.ts",
+      "ignoreWords": ["convo"]
     }
   ],
   "import": ["@cspell/dict-fr-fr/cspell-ext.json"]

--- a/src/content-scripts/TaskButton.svelte
+++ b/src/content-scripts/TaskButton.svelte
@@ -403,6 +403,78 @@
     }
   }
 
+  .button.linkedin {
+    padding: 5px 5px;
+    color: var(--color-text-low-emphasis-shift);
+    font-weight: 500;
+    font-size: 1.4rem;
+    font-family: -apple-system, system-ui, BlinkMacSystemFont, Segoe UI, Roboto,
+      Helvetica Neue, Fira Sans, Ubuntu, Oxygen, Oxygen Sans, Cantarell,
+      Droid Sans, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol,
+      Lucida Grande, Helvetica, Arial, sans-serif;
+    line-height: 1;
+    background-color: #fff;
+    border: 0;
+    border-radius: var(--corner-radius-small) !important;
+    box-shadow: inset 0 0 0 1px #dadce0;
+
+    &:hover,
+    &:focus {
+      color: var(--color-text-low-emphasis-shift);
+      background-color: var(--color-background-none-tint-hover);
+    }
+
+    &:active {
+      background-color: rgba(32, 33, 36, 0.122);
+      box-shadow: 0 1px 2px 0 rgba(60, 64, 67, 0.302),
+        0 1px 3px 1px rgba(60, 64, 67, 0.149);
+    }
+
+    &.decrypt {
+      margin: 8px 3px;
+    }
+
+    &.encrypt {
+      margin-left: 3px;
+    }
+
+    // Enable animations if the user have not disabled them
+    @media (prefers-reduced-motion: no-preference) {
+      transition: box-shadow 0.5s;
+    }
+  }
+
+  .linkedin.encrypt {
+    padding: 5px 5px;
+    color: var(--color-text-low-emphasis-shift);
+    font-size: 0;
+    background-color: var(--rich-text-panel-background);
+    border: transparent;
+    border-radius: 120px !important;
+    box-shadow: none;
+    content: '';
+  }
+
+  // Make the tooltip a flex container, to allow the Cancel button
+  // to be in the right-hand side of the tooltip
+  .tooltip {
+    all: unset;
+    display: flex;
+    gap: 0.5em;
+    align-items: center;
+    width: max-content;
+    max-width: 100%;
+    font-family: system-ui, -apple-system, 'Segoe UI', 'Roboto', 'Ubuntu',
+      'Cantarell', 'Noto Sans', sans-serif;
+    white-space: pre-line;
+
+    // stylelint-disable-next-line no-descending-specificity
+    > :global(button) {
+      // Keep the button on a single line
+      flex-shrink: 0;
+    }
+  }
+
   //pending to decide
   .whatsapp.encrypt {
     padding: 5px 5px;

--- a/src/content-scripts/TaskButton.svelte
+++ b/src/content-scripts/TaskButton.svelte
@@ -444,17 +444,6 @@
     }
   }
 
-  .linkedin.encrypt {
-    padding: 5px 5px;
-    color: var(--color-text-low-emphasis-shift);
-    font-size: 0;
-    background-color: var(--rich-text-panel-background);
-    border: transparent;
-    border-radius: 120px !important;
-    box-shadow: none;
-    content: '';
-  }
-
   // Make the tooltip a flex container, to allow the Cancel button
   // to be in the right-hand side of the tooltip
   .tooltip {
@@ -474,8 +463,16 @@
       flex-shrink: 0;
     }
   }
-
-  //pending to decide
+  .linkedin.encrypt {
+    padding: 5px 5px;
+    color: var(--color-text-low-emphasis-shift);
+    font-size: 0;
+    background-color: var(--rich-text-panel-background);
+    border: transparent;
+    border-radius: 120px !important;
+    box-shadow: none;
+    content: '';
+  }
   .whatsapp.encrypt {
     padding: 5px 5px;
     color: var(--icon);

--- a/src/content-scripts/design.ts
+++ b/src/content-scripts/design.ts
@@ -3,6 +3,7 @@ export enum Design {
   AndorraTelecom = 'andorratelecom',
   Gmail = 'gmail',
   GovernAndorra = 'govern-andorra',
+  Linkedin = 'linkedin',
   Outlook = 'outlook',
   OutlookOld = 'outlook-old',
   Proton = 'proton',

--- a/src/content-scripts/linkedin.ts
+++ b/src/content-scripts/linkedin.ts
@@ -3,6 +3,12 @@
 /**
  * Linkedin functions for content scripts.
  *
+ * Linkedin Documentation: Linkedin has two different window editors that can
+ * pop up at the same time, so we always have to keep track the elements that
+ * corresponds to each window editor To handle with that for every time we call
+ * the handleToolbar we send the entire interface of each window editors so
+ * every knows where its elements are and don't interfere with the other window editor
+ *
  * @module
  */
 
@@ -12,205 +18,8 @@ import tippy from 'tippy.js'
 import { _ } from '$/i18n'
 import { ErrorMessage, ExtensionError } from '~src/error'
 import EncryptButton from './EncryptButton.svelte'
-import {
-  addClickListener,
-  addDecryptButton,
-  addQRDecryptButton,
-  containsEncryptedText,
-  encryptString,
-  FLAG,
-  isEncryptedText,
-  Options,
-  Selectors,
-  extractEncryptedString,
-} from './common'
 import { Design } from './design'
-
-/** Adds a button to a given element to decrypt all encrypted parts found. */
-export const handleMailElement = (
-  mailElement: HTMLElement,
-  options: Options
-): void => {
-  // Mark the element
-  if (FLAG in mailElement.dataset) return
-  mailElement.dataset[FLAG] = '1'
-
-  // If it's not an encrypted mail, ignore it
-  if (mailElement === null) return
-
-  const mailString = mailElement?.querySelector(
-    '.msg-s-event-listitem__body'
-  )?.textContent
-
-  if (!mailString || !containsEncryptedText(mailString)) return
-
-  // Find all encrypted parts
-  const treeWalker = document.createTreeWalker(
-    mailElement,
-    NodeFilter.SHOW_TEXT,
-    {
-      acceptNode: (textNode: Text) =>
-        isEncryptedText(textNode.data)
-          ? NodeFilter.FILTER_ACCEPT
-          : NodeFilter.FILTER_SKIP,
-    }
-  )
-
-  let node: Node | null
-  while ((node = treeWalker.nextNode())) {
-    // Add a "Decrypt" button next to the node
-    if (!node.parentNode?.textContent) continue
-    const encryptedString = extractEncryptedString(node.parentNode.textContent)
-
-    addDecryptButton(node as Text, encryptedString, options)
-    addQRDecryptButton(node as Text, encryptedString, options)
-  }
-}
-
-/** Adds an encryption button in the toolbar. */
-const handleToolbar = (mailElements: MailElements, { design }: Options) => {
-  if (mailElements.toolbar === null || mailElements.toolbar === undefined)
-    return
-
-  const node = mailElements.toolbar.firstElementChild?.children[3]
-
-  if (
-    !mailElements.editor ||
-    !mailElements.editorContent ||
-    !mailElements.send ||
-    !node
-  )
-    return
-
-  if (FLAG in mailElements.toolbar.dataset) return
-  mailElements.toolbar.dataset[FLAG] = '1'
-
-  const target = document.createElement('span')
-  target.id = 'EncryptButton'
-  target.style.display = 'contents'
-  const button = new EncryptButton({
-    target,
-    props: { design },
-  })
-  node.after(target)
-
-  const tooltip = tippy(mailElements.send, {
-    theme: 'light-border',
-  })
-  _.subscribe(($_) => {
-    tooltip.setContent($_('this-mail-is-not-encrypted'))
-  })
-
-  addClickListener(button, async (promise, resolved, rejected, signal) => {
-    if (promise && !resolved && !rejected) return promise
-    if (mailElements.editorContent === undefined) return
-    if (mailElements.editorContent?.textContent === '')
-      throw new ExtensionError(ErrorMessage.MailContentUndefined)
-
-    button.$set({ report: undefined })
-    if (mailElements.editorContent === null) return
-    // Encrypt and replace
-    let encryptedString = await encryptString(
-      // Use innerHTML instead of textContent to support rich text
-      mailElements.editorContent.innerHTML,
-      (report: Report) => {
-        button.$set({ report })
-      },
-      signal
-    )
-
-    encryptedString += '\r'
-
-    mailElements.editorContent.innerHTML = ''
-    // For some reason linkedin messages needs to be in the following format to be able to detect
-    // injected text like our encrypted string
-    // <p> message <br></p>
-    const p = document.createElement('p')
-    const br = document.createElement('br')
-    p.append(encryptedString)
-    p.append(br)
-    mailElements.editorContent.append(p)
-
-    const event = new InputEvent('input', { bubbles: true })
-
-    mailElements.editorContent.dispatchEvent(event)
-
-    tooltip.destroy()
-  })
-}
-
-/**
- * Handles mutations observed by the `MutationObserver` below, i.e.
- * notifications of elements added or removed from the page.
- */
-const handleMutations = (options: Options) => {
-  const mails = document.body.querySelectorAll<HTMLElement>(
-    options.selectors.mail
-  )
-  for (const mail of mails) handleMailElement(mail, options)
-
-  // First window of linkedin editor
-  const firstWindow = document.querySelector(
-    '.scaffold-layout__list-detail-inner'
-  )
-  // Second window of linkedin editor
-  const secondWindow = document.querySelector(
-    '.msg-convo-wrapper.msg-overlay-conversation-bubble'
-  )
-
-  if (!firstWindow && !secondWindow) return
-
-  /** Create a new MailElement */
-  const mailElement: MailElements = {}
-
-  /** If both windows are shown */
-  if (firstWindow && secondWindow) {
-    /** Array of Elements to iterate over all elements for both windows editors in linkedin */
-    const windows: Element[] = [firstWindow, secondWindow]
-
-    /**
-     * I loop for every window editor and then call the handleToolbar so inside
-     * the function know that a certain editor belongs in the window and not
-     * from the other one, so when you click in encrypt he knows that he has to
-     * put the content encrypted in the editorContent of his window.
-     */
-    for (const window of windows) {
-      /**
-       * Because both windows has the same class I can do a querySelector to
-       * obtain the toolbar, ... from the certain window and the call the
-       * handleToolbar function
-       */
-      mailElement.toolbar = window.querySelector<HTMLElement>(selectors.toolbar)
-      mailElement.editor = window.querySelector<HTMLElement>(selectors.editor)
-      mailElement.editorContent = window.querySelector<HTMLElement>(
-        selectors.editorContent
-      )
-      mailElement.send = window.querySelector<HTMLElement>(selectors.send)
-      handleToolbar(mailElement, options)
-    }
-  } else {
-    /**
-     * If only one of both the windows are shown generalWindow variable will be
-     * the only active window, and then do the same as above, assign all the
-     * elements from the Selectors and the call the function
-     */
-    let generalWindow: Element | undefined | null
-    if (firstWindow) generalWindow = firstWindow
-    else if (secondWindow) generalWindow = secondWindow
-
-    mailElement.toolbar = generalWindow?.querySelector<HTMLElement>(
-      selectors.toolbar
-    )
-    mailElement.editor = generalWindow?.querySelector<HTMLElement>(
-      selectors.editor
-    )
-    mailElement.editorContent = generalWindow?.querySelector<HTMLElement>(
-      selectors.editorContent
-    )
-    mailElement.send = generalWindow?.querySelector<HTMLElement>(selectors.send)
-    handleToolbar(mailElement, options)
-  }
-}
+import { Webmail, FLAG, Selectors } from './webmail'
 
 /** HTMLElements from all the parts of a certain window */
 export interface MailElements {
@@ -220,17 +29,207 @@ export interface MailElements {
   send?: HTMLElement | null
 }
 
-/** Observes the DOM for changes. Should work for most webmails. */
-export const observe = (options: Options): void => {
-  // Run the listener on page load
-  handleMutations(options)
-  // Start observing the DOM for changes
-  new MutationObserver(() => {
-    handleMutations(options)
-  }).observe(document.body, {
-    subtree: true,
-    childList: true,
-  })
+class Linkedin extends Webmail {
+  /**
+   * Handles mutations observed by the `MutationObserver` below, i.e.
+   * notifications of elements added or removed from the page.
+   */
+  protected handleMutations = () => {
+    const mails = document.body.querySelectorAll<HTMLElement>(
+      this.selectors.mail
+    )
+    for (const mail of mails) this.handleMailElement(mail)
+
+    // First window of linkedin editor
+    const firstWindow = document.querySelector(
+      '.scaffold-layout__list-detail-inner'
+    )
+    // Second window of linkedin editor
+    const secondWindow = document.querySelector(
+      '.msg-convo-wrapper.msg-overlay-conversation-bubble'
+    )
+
+    if (!firstWindow && !secondWindow) return
+
+    /** Create a new MailElement */
+    const mailElement: MailElements = {}
+
+    /** If both windows are shown */
+    if (firstWindow && secondWindow) {
+      /**
+       * Array of Elements to iterate over all elements for both windows editors
+       * in linkedin
+       */
+      const windows: Element[] = [firstWindow, secondWindow]
+
+      /**
+       * I loop for every window editor and then call the handleToolbarLinkedin
+       * so inside the function know that a certain editor belongs in the window
+       * and not from the other one, so when you click in encrypt he knows that
+       * he has to put the content encrypted in the editorContent of his window.
+       */
+      for (const window of windows) {
+        /**
+         * Because both windows has the same class I can do a querySelector to
+         * obtain the toolbar, ... from the certain window and the call the
+         * handleToolbarLinkedin function
+         */
+        mailElement.toolbar = window.querySelector<HTMLElement>(
+          this.selectors.toolbar
+        )
+        mailElement.editor = window.querySelector<HTMLElement>(
+          this.selectors.editor
+        )
+        mailElement.editorContent = window.querySelector<HTMLElement>(
+          this.selectors.editorContent
+        )
+        mailElement.send = window.querySelector<HTMLElement>(
+          this.selectors.send
+        )
+        this.handleToolbarLinkedin(mailElement)
+      }
+    } else {
+      /**
+       * If only one of both the windows are shown generalWindow variable will
+       * be the only active window, and then do the same as above, assign all
+       * the elements from the Selectors and the call the function
+       */
+      let generalWindow: Element | undefined | null
+      if (firstWindow) generalWindow = firstWindow
+      else if (secondWindow) generalWindow = secondWindow
+
+      mailElement.toolbar = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.toolbar
+      )
+      mailElement.editor = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.editor
+      )
+      mailElement.editorContent = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.editorContent
+      )
+      mailElement.send = generalWindow?.querySelector<HTMLElement>(
+        this.selectors.send
+      )
+      this.handleToolbarLinkedin(mailElement)
+    }
+  }
+
+  /** Adds an encryption button in the toolbar. */
+  protected handleToolbarLinkedin = (mailElements: MailElements): void => {
+    if (mailElements.toolbar === null || mailElements.toolbar === undefined)
+      return
+
+    const node = mailElements.toolbar.firstElementChild?.children[3]
+
+    if (
+      !mailElements.editor ||
+      !mailElements.editorContent ||
+      !mailElements.send ||
+      !node
+    )
+      return
+
+    if (FLAG in mailElements.toolbar.dataset) return
+    mailElements.toolbar.dataset[FLAG] = '1'
+
+    const target = document.createElement('span')
+    target.id = 'EncryptButton'
+    target.style.display = 'contents'
+    const { design } = this
+    const button = new EncryptButton({
+      target,
+      props: { design },
+    })
+    node.after(target)
+
+    const tooltip = tippy(mailElements.send, {
+      theme: 'light-border',
+    })
+    _.subscribe(($_) => {
+      tooltip.setContent($_('this-mail-is-not-encrypted'))
+    })
+
+    this.addClickListener(
+      button,
+      async (promise, resolved, rejected, signal) => {
+        if (promise && !resolved && !rejected) return promise
+        if (mailElements.editorContent === undefined) return
+        if (mailElements.editorContent?.textContent === '')
+          throw new ExtensionError(ErrorMessage.MailContentUndefined)
+
+        button.$set({ report: undefined })
+        if (mailElements.editorContent === null) return
+        // Encrypt and replace
+        let encryptedString = await this.encryptString(
+          // Use innerHTML instead of textContent to support rich text
+          mailElements.editorContent.innerHTML,
+          (report: Report) => {
+            button.$set({ report })
+          },
+          signal
+        )
+
+        encryptedString += '\r'
+
+        mailElements.editorContent.innerHTML = ''
+        // For some reason linkedin messages needs to be in the following format to be able to detect
+        // injected text like our encrypted string
+        // <p> message <br></p>
+        const p = document.createElement('p')
+        const br = document.createElement('br')
+        p.append(encryptedString)
+        p.append(br)
+        mailElements.editorContent.append(p)
+
+        const event = new InputEvent('input', { bubbles: true })
+
+        mailElements.editorContent.dispatchEvent(event)
+
+        tooltip.destroy()
+      }
+    )
+  }
+
+  /** Adds a button to a given element to decrypt all encrypted parts found. */
+  protected handleMailElement = (mailElement: HTMLElement): void => {
+    // Mark the element
+    if (FLAG in mailElement.dataset) return
+    mailElement.dataset[FLAG] = '1'
+
+    // If it's not an encrypted mail, ignore it
+    if (mailElement === null) return
+
+    const mailString = mailElement?.querySelector(
+      '.msg-s-event-listitem__body'
+    )?.textContent
+
+    if (!mailString || !this.containsEncryptedText(mailString)) return
+
+    // Find all encrypted parts
+    const treeWalker = document.createTreeWalker(
+      mailElement,
+      NodeFilter.SHOW_TEXT,
+      {
+        acceptNode: (textNode: Text) =>
+          this.isEncryptedText(textNode.data)
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_SKIP,
+      }
+    )
+
+    let node: Node | null
+    while ((node = treeWalker.nextNode())) {
+      // Add a "Decrypt" button next to the node
+      if (!node.parentNode?.textContent) continue
+      const encryptedString = this.extractEncryptedString(
+        node.parentNode.textContent
+      )
+
+      const workspace = this.initInjectionTarget(node as Text)
+      this.addDecryptButton(workspace, encryptedString)
+      this.addQRDecryptButton(workspace, encryptedString)
+    }
+  }
 }
 
 /** Selectors for interesting HTML Elements of Linkedin. */
@@ -247,5 +246,6 @@ const selectors: Selectors = {
 if (process.env.NODE_ENV !== 'production') debug.enable('*')
 
 setTimeout(() => {
-  observe({ selectors, design: Design.Linkedin })
+  const webmail = new Linkedin(selectors, Design.Linkedin)
+  webmail.observe()
 }, 2000)

--- a/src/content-scripts/linkedin.ts
+++ b/src/content-scripts/linkedin.ts
@@ -1,15 +1,11 @@
 /* eslint-disable complexity */
 /* eslint-disable sonarjs/cognitive-complexity */
+
 /**
  * Linkedin functions for content scripts.
  *
- * Linkedin Documentation: Linkedin has two different window editors that can
- * pop up at the same time, so we always have to keep track the elements that
- * corresponds to each window editor To handle with that for every time we call
- * the handleToolbar we send the entire interface of each window editors so
- * every knows where its elements are and don't interfere with the other window editor
- *
  * @module
+ * @see {@link Linkedin}
  */
 
 import type { Report } from '$/report'
@@ -29,12 +25,20 @@ export interface MailElements {
   send?: HTMLElement | null
 }
 
-class Linkedin extends Webmail {
+/**
+ * Linkedin has two different window editors that can pop up at the same time,
+ * so we always have to keep track of the elements that corresponds to each
+ * window editor, to handle the double editor, every time we call the
+ * {@link handleToolbar} we send the entire interface of each window editors so
+ * every one knows where its elements are and don't interfere with the other
+ * window editor
+ */
+export class Linkedin extends Webmail {
   /**
    * Handles mutations observed by the `MutationObserver` below, i.e.
    * notifications of elements added or removed from the page.
    */
-  protected handleMutations = () => {
+  protected handleMutations = (): void => {
     const mails = document.body.querySelectorAll<HTMLElement>(
       this.selectors.mail
     )

--- a/src/content-scripts/linkedin.ts
+++ b/src/content-scripts/linkedin.ts
@@ -1,0 +1,251 @@
+/* eslint-disable complexity */
+/* eslint-disable sonarjs/cognitive-complexity */
+/**
+ * Linkedin functions for content scripts.
+ *
+ * @module
+ */
+
+import type { Report } from '$/report'
+import { debug } from 'debug'
+import tippy from 'tippy.js'
+import { _ } from '$/i18n'
+import { ErrorMessage, ExtensionError } from '~src/error'
+import EncryptButton from './EncryptButton.svelte'
+import {
+  addClickListener,
+  addDecryptButton,
+  addQRDecryptButton,
+  containsEncryptedText,
+  encryptString,
+  FLAG,
+  isEncryptedText,
+  Options,
+  Selectors,
+  extractEncryptedString,
+} from './common'
+import { Design } from './design'
+
+/** Adds a button to a given element to decrypt all encrypted parts found. */
+export const handleMailElement = (
+  mailElement: HTMLElement,
+  options: Options
+): void => {
+  // Mark the element
+  if (FLAG in mailElement.dataset) return
+  mailElement.dataset[FLAG] = '1'
+
+  // If it's not an encrypted mail, ignore it
+  if (mailElement === null) return
+
+  const mailString = mailElement?.querySelector(
+    '.msg-s-event-listitem__body'
+  )?.textContent
+
+  if (!mailString || !containsEncryptedText(mailString)) return
+
+  // Find all encrypted parts
+  const treeWalker = document.createTreeWalker(
+    mailElement,
+    NodeFilter.SHOW_TEXT,
+    {
+      acceptNode: (textNode: Text) =>
+        isEncryptedText(textNode.data)
+          ? NodeFilter.FILTER_ACCEPT
+          : NodeFilter.FILTER_SKIP,
+    }
+  )
+
+  let node: Node | null
+  while ((node = treeWalker.nextNode())) {
+    // Add a "Decrypt" button next to the node
+    if (!node.parentNode?.textContent) continue
+    const encryptedString = extractEncryptedString(node.parentNode.textContent)
+
+    addDecryptButton(node as Text, encryptedString, options)
+    addQRDecryptButton(node as Text, encryptedString, options)
+  }
+}
+
+/** Adds an encryption button in the toolbar. */
+const handleToolbar = (mailElements: MailElements, { design }: Options) => {
+  if (mailElements.toolbar === null || mailElements.toolbar === undefined)
+    return
+
+  const node = mailElements.toolbar.firstElementChild?.children[3]
+
+  if (
+    !mailElements.editor ||
+    !mailElements.editorContent ||
+    !mailElements.send ||
+    !node
+  )
+    return
+
+  if (FLAG in mailElements.toolbar.dataset) return
+  mailElements.toolbar.dataset[FLAG] = '1'
+
+  const target = document.createElement('span')
+  target.id = 'EncryptButton'
+  target.style.display = 'contents'
+  const button = new EncryptButton({
+    target,
+    props: { design },
+  })
+  node.after(target)
+
+  const tooltip = tippy(mailElements.send, {
+    theme: 'light-border',
+  })
+  _.subscribe(($_) => {
+    tooltip.setContent($_('this-mail-is-not-encrypted'))
+  })
+
+  addClickListener(button, async (promise, resolved, rejected, signal) => {
+    if (promise && !resolved && !rejected) return promise
+    if (mailElements.editorContent === undefined) return
+    if (mailElements.editorContent?.textContent === '')
+      throw new ExtensionError(ErrorMessage.MailContentUndefined)
+
+    button.$set({ report: undefined })
+    if (mailElements.editorContent === null) return
+    // Encrypt and replace
+    let encryptedString = await encryptString(
+      // Use innerHTML instead of textContent to support rich text
+      mailElements.editorContent.innerHTML,
+      (report: Report) => {
+        button.$set({ report })
+      },
+      signal
+    )
+
+    encryptedString += '\r'
+
+    mailElements.editorContent.innerHTML = ''
+    // For some reason linkedin messages needs to be in the following format to be able to detect
+    // injected text like our encrypted string
+    // <p> message <br></p>
+    const p = document.createElement('p')
+    const br = document.createElement('br')
+    p.append(encryptedString)
+    p.append(br)
+    mailElements.editorContent.append(p)
+
+    const event = new InputEvent('input', { bubbles: true })
+
+    mailElements.editorContent.dispatchEvent(event)
+
+    tooltip.destroy()
+  })
+}
+
+/**
+ * Handles mutations observed by the `MutationObserver` below, i.e.
+ * notifications of elements added or removed from the page.
+ */
+const handleMutations = (options: Options) => {
+  const mails = document.body.querySelectorAll<HTMLElement>(
+    options.selectors.mail
+  )
+  for (const mail of mails) handleMailElement(mail, options)
+
+  // First window of linkedin editor
+  const firstWindow = document.querySelector(
+    '.scaffold-layout__list-detail-inner'
+  )
+  // Second window of linkedin editor
+  const secondWindow = document.querySelector(
+    '.msg-convo-wrapper.msg-overlay-conversation-bubble'
+  )
+
+  if (!firstWindow && !secondWindow) return
+
+  /** Create a new MailElement */
+  const mailElement: MailElements = {}
+
+  /** If both windows are shown */
+  if (firstWindow && secondWindow) {
+    /** Array of Elements to iterate over all elements for both windows editors in linkedin */
+    const windows: Element[] = [firstWindow, secondWindow]
+
+    /**
+     * I loop for every window editor and then call the handleToolbar so inside
+     * the function know that a certain editor belongs in the window and not
+     * from the other one, so when you click in encrypt he knows that he has to
+     * put the content encrypted in the editorContent of his window.
+     */
+    for (const window of windows) {
+      /**
+       * Because both windows has the same class I can do a querySelector to
+       * obtain the toolbar, ... from the certain window and the call the
+       * handleToolbar function
+       */
+      mailElement.toolbar = window.querySelector<HTMLElement>(selectors.toolbar)
+      mailElement.editor = window.querySelector<HTMLElement>(selectors.editor)
+      mailElement.editorContent = window.querySelector<HTMLElement>(
+        selectors.editorContent
+      )
+      mailElement.send = window.querySelector<HTMLElement>(selectors.send)
+      handleToolbar(mailElement, options)
+    }
+  } else {
+    /**
+     * If only one of both the windows are shown generalWindow variable will be
+     * the only active window, and then do the same as above, assign all the
+     * elements from the Selectors and the call the function
+     */
+    let generalWindow: Element | undefined | null
+    if (firstWindow) generalWindow = firstWindow
+    else if (secondWindow) generalWindow = secondWindow
+
+    mailElement.toolbar = generalWindow?.querySelector<HTMLElement>(
+      selectors.toolbar
+    )
+    mailElement.editor = generalWindow?.querySelector<HTMLElement>(
+      selectors.editor
+    )
+    mailElement.editorContent = generalWindow?.querySelector<HTMLElement>(
+      selectors.editorContent
+    )
+    mailElement.send = generalWindow?.querySelector<HTMLElement>(selectors.send)
+    handleToolbar(mailElement, options)
+  }
+}
+
+/** HTMLElements from all the parts of a certain window */
+export interface MailElements {
+  toolbar?: HTMLElement | null
+  editor?: HTMLElement | null
+  editorContent?: HTMLElement | null
+  send?: HTMLElement | null
+}
+
+/** Observes the DOM for changes. Should work for most webmails. */
+export const observe = (options: Options): void => {
+  // Run the listener on page load
+  handleMutations(options)
+  // Start observing the DOM for changes
+  new MutationObserver(() => {
+    handleMutations(options)
+  }).observe(document.body, {
+    subtree: true,
+    childList: true,
+  })
+}
+
+/** Selectors for interesting HTML Elements of Linkedin. */
+/** Both windows from linkedin shares the same class selectors */
+const selectors: Selectors = {
+  mail: '.msg-s-event__content',
+  toolbar: '.msg-form__footer',
+  editor: '.msg-form',
+  editorContent: '.msg-form__contenteditable',
+  send: '.msg-form__send-button',
+}
+
+// Enable logging in the page console (not the extension console)
+if (process.env.NODE_ENV !== 'production') debug.enable('*')
+
+setTimeout(() => {
+  observe({ selectors, design: Design.Linkedin })
+}, 2000)

--- a/webmails.json
+++ b/webmails.json
@@ -3,6 +3,7 @@
   "gmail": ["https://mail.google.com/mail/*"],
   "govern-full": ["https://missatgeria.govern.ad/*"],
   "govern-light": ["https://missatgeria.govern.ad/*"],
+  "linkedin": ["https://www.linkedin.com/*"],
   "outlook": ["https://outlook.live.com/mail/*"],
   "outlook-old": ["https://webmail.mail.ovh.net/owa/*"],
   "proton": ["https://mail.protonmail.com/*"],


### PR DESCRIPTION
Now the encrypt button tooltip show a message when the mail content is empty, so you can't encrypt an empty message

![Screenshot from 2021-11-25 10-15-17](https://user-images.githubusercontent.com/29331799/143413496-f820e5a1-f45c-416d-a1a8-d07351b7fa4c.png)
