### PR TITLE
fix: can't encrypt encrypted mails

### DIFF
--- a/src/content-scripts/webmail.ts
+++ b/src/content-scripts/webmail.ts
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import type { Design } from './design'
 import type { Report, Reporter } from '~src/report'
 import * as base85 from 'base85'
@@ -361,6 +362,7 @@ export class Webmail {
   }
 
   /** Adds an encryption button in the toolbar. */
+  // eslint-disable-next-line sonarjs/cognitive-complexity
   protected handleToolbar(toolbar: HTMLElement): void {
     const editor = toolbar.closest(this.selectors.editor)
 
@@ -392,6 +394,10 @@ export class Webmail {
 
         if (mail.isEmpty())
           throw new ExtensionError(ErrorMessage.MailContentUndefined)
+
+        // Error message is shown if the mail is already encrypted
+        if (this.containsEncryptedText(mail.getContent()))
+          throw new ExtensionError(ErrorMessage.MailAlreadyEncrypted)
 
         button.$set({ report: undefined })
         let mailContent = mail.getContent()

--- a/src/error.ts
+++ b/src/error.ts
@@ -23,7 +23,8 @@ export enum ErrorMessage {
   UnknownError = 'Unknown error.',
   UnknownPhoneError = 'Unknown phone error.',
   WrongKey = 'Wrong key.',
-  CharacterLimit = 'Character Limit',
+  CharacterLimit = 'Character Limit.',
+  MailAlreadyEncrypted = 'Mail Already Encrypted.',
 }
 
 /**

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -81,6 +81,10 @@ export const translateError = derived(_, ($_) => (error: ErrorMessage) => {
 
     case ErrorMessage.CharacterLimit:
       return $_('character-limit-exceeded')
+
+    case ErrorMessage.MailAlreadyEncrypted:
+      return $_('mail-already-encrypted')
+
     // This switch statement is exhaustive
     // No default
   }

--- a/static/locales/en/strings.json
+++ b/static/locales/en/strings.json
@@ -62,5 +62,6 @@
   "character-limit-exceeded": "Character limit exceeded (2231)",
   "pairing-with-phone-name": "Pairing with {phoneName}",
   "click-to-autofill": "Click to autofill",
-  "autofill-successful": "Autofill successful"
+  "autofill-successful": "Autofill successful",
+  "mail-already-encrypted": "Mail already encrypted"
 }


### PR DESCRIPTION
Fixed: Now we can't encrypt and encrypted message.

![Screenshot from 2021-11-29 15-00-53](https://user-images.githubusercontent.com/29331799/143881853-ccd7028f-c504-4e63-b5ad-b93ddcf3e803.png)