### PR TITLE
fix: icloud iframes of qrcode and decrypt showed correctly

### DIFF
--- a/src/content-scripts/icloud.ts
+++ b/src/content-scripts/icloud.ts
@@ -39,3 +39,10 @@ setTimeout(() => {
   const webmail = new Webmail(selectors, Design.iCloud)
   webmail.observe()
 }, 1000)
+
+/** For some reason with setInterval icloud does update the web with the height atributtes */
+setInterval(() => {
+  const iframe = document.querySelector('iframe') as HTMLElement
+  // Change the height of the iframe so we can see the encrypted message or the qrcode
+  iframe.setAttribute('height', '100%')
+}, 2000)

--- a/src/content-scripts/webmail.ts
+++ b/src/content-scripts/webmail.ts
@@ -185,7 +185,6 @@ export class Webmail {
   }
 
   /** Adds a button to a given element to decrypt all encrypted parts found. */
-  // eslint-disable-next-line complexity
   protected handleMailElement = (mailElement: HTMLElement): void => {
     // Mark the element
     if (FLAG in mailElement.dataset) return

--- a/webmails.json
+++ b/webmails.json
@@ -3,7 +3,10 @@
   "gmail": ["https://mail.google.com/mail/*"],
   "govern-full": ["https://missatgeria.govern.ad/*"],
   "govern-light": ["https://missatgeria.govern.ad/*"],
-  "icloud": ["https://www-mail.icloud-sandbox.com/*"],
+  "icloud": [
+    "https://www-mail.icloud-sandbox.com/*",
+    "https://www.icloud.com/*"
+  ],
   "linkedin": ["https://www.linkedin.com/*"],
   "outlook": ["https://outlook.live.com/mail/*"],
   "outlook-old": ["https://webmail.mail.ovh.net/owa/*"],


### PR DESCRIPTION
Fixed, now the qrcode and decrypt iframe are shown correctly

QRCode
![aaa](https://user-images.githubusercontent.com/29331799/144061643-644b8170-848c-40a9-a965-1a5fa7c95298.png)

Decrypt
![aaaa](https://user-images.githubusercontent.com/29331799/144061672-6fe9defd-9275-4f20-98fd-ece29f4eec86.png)
